### PR TITLE
🎉 月次カウンターリセット機能の実装

### DIFF
--- a/tmp/githubsh.log
+++ b/tmp/githubsh.log
@@ -321,3 +321,23 @@ Output:
 [2025-07-19 18:20:08] [INFO] Starting GitHub Shell Manager
 [2025-07-19 18:20:08] [INFO] Todo No: srv-tools#287, Stage: 3
 [2025-07-20 03:20:08] [INFO] 実行中: git add .
+[2025-07-20 03:21:21] [INFO] GitHubレポートを作成しました: https://github.com/geeknow112/srv-tools/issues/290
+[2025-07-20 03:21:22] [INFO] 元のIssue #282 をクローズしました
+[2025-07-20 03:21:22] [INFO] 実行レポートを生成しました: /mnt/c/Users/youre/Documents/git_repo/srv-tools/tmp/execution_report_20250720_032120.json
+[2025-07-19 18:28:24] [INFO] Starting GitHub Shell Manager
+[2025-07-19 18:28:24] [INFO] Todo No: 月次カウンターリセット機能テスト, Stage: 0
+[2025-07-19 18:28:24] [INFO] Creating GitHub issue: 月次カウンターリセット機能テスト
+[2025-07-19 18:28:25] [INFO] GitHub issue created: https://github.com/geeknow112/srv-tools/issues/291
+[2025-07-19 18:28:25] [INFO] Process completed successfully!
+[2025-07-19 18:28:36] [INFO] Starting GitHub Shell Manager
+[2025-07-19 18:28:36] [INFO] Todo No: srv-tools#291, Stage: 1
+[2025-07-20 03:28:36] [INFO] 月が変わりました (202506 → 202507)。カウンターを001にリセットします。
+[2025-07-20 03:28:36] [INFO] 実行中: cd /mnt/c/Users/youre/Documents/git_repo/srv-tools/tmp/../migrations/
+[2025-07-20 03:28:36] [INFO] コマンドが正常に完了しました
+[2025-07-20 03:28:37] [INFO] 実行中: git checkout -b migration20250720001
+[2025-07-20 03:28:37] [INFO] コマンドが正常に完了しました
+[2025-07-20 03:28:38] [INFO] 実行中: cp -p /mnt/c/Users/youre/Documents/git_repo/srv-tools/tmp/../migrations/migration-20250703-001.go /mnt/c/Users/youre/Documents/git_repo/srv-tools/tmp/../migrations/migration20250720001.go
+[2025-07-20 03:28:38] [INFO] コマンドが正常に完了しました
+[2025-07-20 03:28:39] [INFO] ステージ 1 for srv-tools#291 が正常に完了しました
+[2025-07-20 03:28:39] [INFO] 実行レポートを生成しました: /mnt/c/Users/youre/Documents/git_repo/srv-tools/tmp/execution_report_20250720_032839.json
+[2025-07-20 03:28:39] [INFO] Process completed successfully!


### PR DESCRIPTION
## 🚀 新機能: 月次カウンターリセット

### 📅 **実装内容**
- **月が変わると自動的にカウンターを001にリセット**
- **カウンターファイル形式**: `カウンター値:月` (例: `12:202507`)
- **自動検出**: 前回の月と現在の月を比較してリセット判定
- **ログ出力**: 月変更時にリセット通知メッセージ

### 🔧 **技術詳細**

#### **getNextNo()メソッドの改良**
- **新形式対応**: `1:202507` 形式でカウンターと月を管理
- **月変更検出**: `date('Ym')` で現在月と保存月を比較
- **自動リセット**: 月が変わった場合は1にリセット
- **後方互換性**: 古い形式のファイルも自動変換

#### **setNextNo()メソッドの改良**
- **月情報保存**: カウンター更新時に現在月も保存
- **詳細ログ**: `カウンターを更新しました: 13 (月: 202507)`

### 📊 **テスト結果**

#### ✅ **月次リセット機能テスト**
- **テスト条件**: 202506 → 202507 への月変更シミュレーション
- **実行結果**: 
  
- **ファイル形式**: `1:202507` (新形式で正常保存)

#### ✅ **動作確認**
- **migration20250720001.go**: 正しく001番で作成
- **カウンターファイル**: `1:202507` 形式で保存
- **ログ出力**: 月変更を正しく検出・通知

### 🚀 **運用上の利点**

#### **月次管理の改善**
- **ファイル整理**: 月ごとに001から開始で管理しやすい
- **視認性向上**: migration20250720001, migration20250801001 など
- **運用効率**: 月次でのマイグレーション管理が容易

#### **自動化の向上**
- **手動操作不要**: 月が変わると自動的にリセット
- **透明性**: ログでリセット実行を確認可能
- **安全性**: 既存のカウンターを保護しつつ新形式に移行

### 📋 **使用例**

#### **7月の場合**


#### **8月になった場合**


### 🎯 **完成した機能一覧**

1. ✅ **migration***.goファイル**: `../migrations/`フォルダに配置
2. ✅ **Stage 4でmerge待機**: インタラクティブプロンプト
3. ✅ **リモートブランチ削除**: `git push origin --delete`実行
4. ✅ **結果Issue投稿**: 成功時・エラー時両方で自動作成
5. ✅ **日本語レポート**: 完全に日本語化されたレポート
6. ✅ **元Issueクローズ**: Stage 4成功時に自動クローズ
7. ✅ **月次カウンターリセット**: 月が変わると001から開始 🆕

### 🔄 **カウンターファイル形式**

#### **旧形式**


#### **新形式**


**後方互換性を保ちつつ、月次管理機能を追加しました！**

## 🎉 **GitHub Shell Managerがさらに使いやすくなりました！**

**Ready for review and merge!** 🚀